### PR TITLE
Change C4FSK pulse filter to Gaussian

### DIFF
--- a/Mode2RX.cpp
+++ b/Mode2RX.cpp
@@ -38,8 +38,8 @@ const uint16_t RX_FILTER_LEN = 45U;
 
 const q15_t SCALING_FACTOR = 18750;      // Q15(0.55)
 
-const uint8_t MAX_SYNC_BIT_ERRS     = 5U;
-const uint8_t MAX_SYNC_SYMBOLS_ERRS = 4U;
+const uint8_t MAX_SYNC_BIT_ERRS     = 2U;
+const uint8_t MAX_SYNC_SYMBOLS_ERRS = 1U;
 
 const uint8_t BIT_MASK_TABLE[] = {0x80U, 0x40U, 0x20U, 0x10U, 0x08U, 0x04U, 0x02U, 0x01U};
 

--- a/Mode2RX.cpp
+++ b/Mode2RX.cpp
@@ -23,11 +23,18 @@
 #include "Mode2RX.h"
 #include "Utils.h"
 
-// Generated using rcosdesign(0.2, 8, 5, 'sqrt') in MATLAB
-static q15_t RRC_0_2_FILTER[] = {401, 104, -340, -731, -847, -553, 112, 909, 1472, 1450, 683, -675, -2144, -3040, -2706, -770, 2667, 6995,
-                                 11237, 14331, 15464, 14331, 11237, 6995, 2667, -770, -2706, -3040, -2144, -675, 683, 1450, 1472, 909, 112,
-                                 -553, -847, -731, -340, 104, 401, 0};
-const uint16_t RRC_0_2_FILTER_LEN = 42U;
+// LPF, cutoff = 0.9 * 4800 (4320)
+static q15_t RX_FILTER[] = {  \
+      -9, -41, -30, 32, 89, \
+      44, -107, -193, -33, 279, \
+      349, -64, -602, -532, 352, \
+      1175, 706, -1090, -2379, -830, \
+      3951, 9411, 11818, 9411, 3951, \
+      -830, -2379, -1090, 706, 1175, \
+      352, -532, -602, -64, 349, \
+      279, -33, -193, -107, 44, \
+      89, 32, -30, -41, -9 };
+const uint16_t RX_FILTER_LEN = 42U;
 
 const q15_t SCALING_FACTOR = 18750;      // Q15(0.55)
 
@@ -63,9 +70,9 @@ m_countdown(0U),
 m_packet()
 {
   ::memset(m_rrc02State, 0x00U, 70U * sizeof(q15_t));
-  m_rrc02Filter.numTaps = RRC_0_2_FILTER_LEN;
+  m_rrc02Filter.numTaps = RX_FILTER_LEN;
   m_rrc02Filter.pState  = m_rrc02State;
-  m_rrc02Filter.pCoeffs = RRC_0_2_FILTER;
+  m_rrc02Filter.pCoeffs = RX_FILTER;
 }
 
 void CMode2RX::reset()

--- a/Mode2RX.cpp
+++ b/Mode2RX.cpp
@@ -34,7 +34,7 @@ static q15_t RX_FILTER[] = {  \
       352, -532, -602, -64, 349, \
       279, -33, -193, -107, 44, \
       89, 32, -30, -41, -9 };
-const uint16_t RX_FILTER_LEN = 42U;
+const uint16_t RX_FILTER_LEN = 45U;
 
 const q15_t SCALING_FACTOR = 18750;      // Q15(0.55)
 

--- a/Mode2TX.cpp
+++ b/Mode2TX.cpp
@@ -22,11 +22,18 @@
 #include "Globals.h"
 #include "Mode2TX.h"
 
-// Generated using rcosdesign(0.2, 8, 5, 'sqrt') in MATLAB
-static q15_t RRC_0_2_FILTER[] = {0, 0, 0, 0, 850, 219, -720, -1548, -1795, -1172, 237, 1927, 3120, 3073, 1447, -1431, -4544, -6442,
-                                 -5735, -1633, 5651, 14822, 23810, 30367, 32767, 30367, 23810, 14822, 5651, -1633, -5735, -6442,
-                                 -4544, -1431, 1447, 3073, 3120, 1927, 237, -1172, -1795, -1548, -720, 219, 850}; // numTaps = 45, L = 5
-const uint16_t RRC_0_2_FILTER_PHASE_LEN = 9U; // phaseLength = numTaps/L
+// Gaussian BT 0.6 convolved with 5 sample unit step function.
+static q15_t TX_PULSE_FILTER[] = {  \
+      0, 0, 0, 0, 0, \
+      0, 0, 0, 0, 0, \
+      0, 0, 0, 0, 0, \
+      0, 17, 319, 2659, 10668, \
+      22736, 30728, 32767, 30728, 22736, \
+      10668, 2659, 319, 17, 0, \
+      0, 0, 0, 0, 0, \
+      0, 0, 0, 0, 0, \
+      0, 0, 0, 0, 0 };
+const uint16_t TX_PULSE_FILTER_PHASE_LEN = 9U; // phaseLength = numTaps/L
 
 const q15_t LEVELA =  1362;
 const q15_t LEVELB =  454;
@@ -57,8 +64,8 @@ m_tokens()
   ::memset(m_modState, 0x00U, 16U * sizeof(q15_t));
 
   m_modFilter.L           = MODE2_RADIO_SYMBOL_LENGTH;
-  m_modFilter.phaseLength = RRC_0_2_FILTER_PHASE_LEN;
-  m_modFilter.pCoeffs     = RRC_0_2_FILTER;
+  m_modFilter.phaseLength = TX_PULSE_FILTER_PHASE_LEN;
+  m_modFilter.pCoeffs     = TX_PULSE_FILTER;
   m_modFilter.pState      = m_modState;
 }
 


### PR DESCRIPTION
Change transmit C4FSK pulse filter to Gaussian. Change receive C4FSK pulse filter to complement Gaussian transmit filter. Adjust  MAX_SYNC_BIT_ERRS down to 2. Adjust MAX_SYNC_SYMBOLS_ERRS down to 1. 

I've tested this on a ZUM v1.0 MMDVM-HAT with F446 processor against a NinoTNC. Transmit and receive are working in both directions.